### PR TITLE
build: Make sure required directory "extra" exists

### DIFF
--- a/debian/update.sh
+++ b/debian/update.sh
@@ -75,6 +75,7 @@ EOF
 (cd linux; eval $make olddefconfig)
 (cd linux; eval $make -j8 zImage modules dtbs 2>&1 | tee /tmp/out)
 version=`cat $BUILDDIR/include/config/kernel.release`
+[ ! -d "extra" ] && mkdir "extra"
 echo "_ _ $version" > extra/uname_string
 copy_files
 


### PR DESCRIPTION
With commit a03872b7d15f directory "extra" was removed from the repository
which now results in an abortion of the build process as soon as the build
script tries to create the file "uname_string" in that directory. So make
sure that directory "extra" is created by the build script if it does not
exist yet.

Signed-off-by: Lino Sanfilippo <l.sanfilippo@kunbus.com>