### PR TITLE
kernelbakery: remove the "x86-64" from egrep to find the ELF for host…

### DIFF
--- a/debian/update.sh
+++ b/debian/update.sh
@@ -14,7 +14,7 @@ copy_files (){
 		--files-from=<(cd linux; find $(find arch/arm -name include -o -name scripts -type d) -type f) linux/ "$destdir/"
 	rsync -aHAX \
 		--files-from=<(cd $BUILDDIR; find arch/arm/include Module.symvers .config include scripts -type f) $BUILDDIR "$destdir/"
-	find $destdir/scripts -type f | xargs file | egrep 'ELF .* x86-64' | cut -d: -f1 | xargs rm
+	find $destdir/scripts -type f | xargs file | egrep 'ELF .*' | cut -d: -f1 | xargs rm
 	find $destdir/scripts -type f -name '*.cmd' | xargs rm
 	ln -sf "/usr/src/linux-headers-$version" "headers/lib/modules/$version/build"
 


### PR DESCRIPTION
… machine.

when the kernel is built with debian/update.sh,  some binaries in elf format for
host os are generated.Those files need to be removed from the image for target platform.
this was egrep with "ELF .* x86-64", which gets nothing if the kernel is built on a
non "x86-64" machine

Signed-off-by: Zhi Han <z.han@kunbus.com>