### PR TITLE
kernelbackery: add the missing deb packages

### DIFF
--- a/README
+++ b/README
@@ -16,6 +16,7 @@ Intended usage:
     apt-get install device-tree-compiler
     apt-get install gcc-arm-linux-gnueabihf
     apt-get install build-essential:native debhelper quilt bc
+    apt-get install bison flex libssl-dev
     git clone -b revpi-4.19 https://github.com/RevolutionPi/linux
     git clone https://github.com/RevolutionPi/piControl
     git clone https://github.com/RevolutionPi/kernelbakery


### PR DESCRIPTION
to use the debian/update.sh build the kernel, the added packages are
needed, but normally it is not included in the distro

Signek-off-by: Zhi Han <z.han@kunbus.com>