### PR TITLE
Create 1:9.20211203-4.19.95+revpi1 release [REVPI-1772]

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+raspberrypi-firmware (1:9.20211203-4.19.95+revpi1) stable; urgency=medium
+
+  * Revert "brcmfmac: Add support for reading mac address from device tree"
+  * Revert "ARM: dts: revpi-flat: Add support for wifi mac address"
+  * piControl:compact: handle missing config settings
+  * piControl:flat: handle missing config settings
+
+ -- Philipp Rosenberger <p.rosenberger@kunbus.com>  Fri, 03 Dec 2021 13:57:20 +0100
+
 raspberrypi-firmware (1:9.20211109-4.19.95+revpi1) stable; urgency=medium
 
   * dts/revpi-flat: Add WLAN enable


### PR DESCRIPTION
https://github.com/RevolutionPi/linux/releases/tag/raspberrypi-kernel_1%259.20211203-4.19.95%2Brevpi1
https://github.com/RevolutionPi/piControl/releases/tag/raspberrypi-kernel_1%259.20211203-4.19.95%2Brevpi1

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>