### PR TITLE
Make build process more generic / prepare v7l support [REVPI-1808]

### DIFF
--- a/debian/gen_bootloader_postinst_preinst.sh
+++ b/debian/gen_bootloader_postinst_preinst.sh
@@ -5,7 +5,7 @@ if ! [ -d ../boot ]; then
   exit 1
 fi
 
-version=`cat ../extra/uname_string | cut -f 3 -d ' ' | tr -d +`
+version=`cat ../extra/uname_string | cut -f 3 -d ' '| sed -Ee 's/(-v[78]l?)?\+$//'`
 
 printf "#!/bin/sh\n" > raspberrypi-kernel.postinst
 printf "#!/bin/sh\n" > raspberrypi-kernel.preinst
@@ -29,12 +29,16 @@ export INITRD=No
 if [ -d "/etc/kernel/preinst.d" ]; then
   run-parts -v --report --exit-on-error --arg=${version}+ --arg=/boot/kernel.img /etc/kernel/preinst.d
   run-parts -v --report --exit-on-error --arg=${version}-v7+ --arg=/boot/kernel7.img /etc/kernel/preinst.d
+  run-parts -v --report --exit-on-error --arg=${version}-v7l+ --arg=/boot/kernel7l.img /etc/kernel/preinst.d
 fi
 if [ -d "/etc/kernel/preinst.d/${version}+" ]; then
   run-parts -v --report --exit-on-error --arg=${version}+ --arg=/boot/kernel.img /etc/kernel/preinst.d/${version}+
 fi
 if [ -d "/etc/kernel/preinst.d/${version}-v7+" ]; then
   run-parts -v --report --exit-on-error --arg=${version}-v7+ --arg=/boot/kernel7.img /etc/kernel/preinst.d/${version}-v7+
+fi
+if [ -d "/etc/kernel/preinst.d/${version}-v7l+" ]; then
+  run-parts -v --report --exit-on-error --arg=${version}-v7l+ --arg=/boot/kernel7l.img /etc/kernel/preinst.d/${version}-v7l+
 fi
 EOF
 
@@ -43,12 +47,16 @@ export INITRD=No
 if [ -d "/etc/kernel/postinst.d" ]; then
   run-parts -v --report --exit-on-error --arg=${version}+ --arg=/boot/kernel.img /etc/kernel/postinst.d
   run-parts -v --report --exit-on-error --arg=${version}-v7+ --arg=/boot/kernel7.img /etc/kernel/postinst.d
+  run-parts -v --report --exit-on-error --arg=${version}-v7l+ --arg=/boot/kernel7l.img /etc/kernel/postinst.d
 fi
 if [ -d "/etc/kernel/postinst.d/${version}+" ]; then
   run-parts -v --report --exit-on-error --arg=${version}+ --arg=/boot/kernel.img /etc/kernel/postinst.d/${version}+
 fi
 if [ -d "/etc/kernel/postinst.d/${version}-v7+" ]; then
   run-parts -v --report --exit-on-error --arg=${version}-v7+ --arg=/boot/kernel7.img /etc/kernel/postinst.d/${version}-v7+
+fi
+if [ -d "/etc/kernel/postinst.d/${version}-v7l+" ]; then
+  run-parts -v --report --exit-on-error --arg=${version}-v7l+ --arg=/boot/kernel7l.img /etc/kernel/postinst.d/${version}-v7l+
 fi
 
 # wheezy and jessie images shipped with a "kunbus" overlay
@@ -85,12 +93,16 @@ export INITRD=No
 if [ -d "/etc/kernel/prerm.d" ]; then
   run-parts -v --report --exit-on-error --arg=${version}+ --arg=/boot/kernel.img /etc/kernel/prerm.d
   run-parts -v --report --exit-on-error --arg=${version}-v7+ --arg=/boot/kernel7.img /etc/kernel/prerm.d
+  run-parts -v --report --exit-on-error --arg=${version}-v7l+ --arg=/boot/kernel7l.img /etc/kernel/prerm.d
 fi
 if [ -d "/etc/kernel/prerm.d/${version}+" ]; then
   run-parts -v --report --exit-on-error --arg=${version}+ --arg=/boot/kernel.img /etc/kernel/prerm.d/${version}+
 fi
 if [ -d "/etc/kernel/prerm.d/${version}-v7+" ]; then
   run-parts -v --report --exit-on-error --arg=${version}-v7+ --arg=/boot/kernel7.img /etc/kernel/prerm.d/${version}-v7+
+fi
+if [ -d "/etc/kernel/prerm.d/${version}-v7l+" ]; then
+  run-parts -v --report --exit-on-error --arg=${version}-v7l+ --arg=/boot/kernel7l.img /etc/kernel/prerm.d/${version}-v7l+
 fi
 EOF
 
@@ -99,12 +111,16 @@ export INITRD=No
 if [ -d "/etc/kernel/postrm.d" ]; then
   run-parts -v --report --exit-on-error --arg=${version}+ --arg=/boot/kernel.img /etc/kernel/postrm.d
   run-parts -v --report --exit-on-error --arg=${version}-v7+ --arg=/boot/kernel7.img /etc/kernel/postrm.d
+  run-parts -v --report --exit-on-error --arg=${version}-v7l+ --arg=/boot/kernel7l.img /etc/kernel/postrm.d
 fi
 if [ -d "/etc/kernel/postrm.d/${version}+" ]; then
   run-parts -v --report --exit-on-error --arg=${version}+ --arg=/boot/kernel.img /etc/kernel/postrm.d/${version}+
 fi
 if [ -d "/etc/kernel/postrm.d/${version}-v7+" ]; then
   run-parts -v --report --exit-on-error --arg=${version}-v7+ --arg=/boot/kernel7.img /etc/kernel/postrm.d/${version}-v7+
+fi
+if [ -d "/etc/kernel/postrm.d/${version}-v7l+" ]; then
+  run-parts -v --report --exit-on-error --arg=${version}-v7l+ --arg=/boot/kernel7l.img /etc/kernel/postrm.d/${version}-v7l+
 fi
 EOF
 
@@ -113,6 +129,7 @@ export INITRD=No
 if [ -d "/etc/kernel/header_postinst.d" ]; then
   run-parts -v --verbose --exit-on-error --arg=${version}+ /etc/kernel/header_postinst.d
   run-parts -v --verbose --exit-on-error --arg=${version}-v7+ /etc/kernel/header_postinst.d
+  run-parts -v --verbose --exit-on-error --arg=${version}-v7l+ /etc/kernel/header_postinst.d
 fi
 
 if [ -d "/etc/kernel/header_postinst.d/${version}+" ]; then
@@ -121,6 +138,10 @@ fi
 
 if [ -d "/etc/kernel/header_postinst.d/${version}-v7+" ]; then
   run-parts -v --verbose --exit-on-error --arg=${version}-v7+ /etc/kernel/header_postinst.d/${version}-v7+
+fi
+
+if [ -d "/etc/kernel/header_postinst.d/${version}-v7l+" ]; then
+  run-parts -v --verbose --exit-on-error --arg=${version}-v7l+ /etc/kernel/header_postinst.d/${version}-v7l+
 fi
 EOF
 

--- a/debian/update.sh
+++ b/debian/update.sh
@@ -5,7 +5,7 @@ copy_files (){
 	mkdir -p "$destdir"
 	mkdir -p "headers/lib/modules/$version"
 	rsync -aHAX \
-		--files-from=<(cd linux; find -name Makefile\* -o -name Kconfig\* -o -name \*.pl | grep -E -v '^\./debian') linux/ "$destdir/"
+		--files-from=<(cd linux; find . -name Makefile\* -o -name Kconfig\* -o -name \*.pl | grep -E -v '^\./debian') linux/ "$destdir/"
 	rsync -aHAX \
 		--files-from=<(cd linux; find arch/arm/include include scripts -type f) linux/ "$destdir/"
 	rsync -aHAX \
@@ -24,7 +24,7 @@ copy_files (){
 	find "$destdir/scripts" -type f -name '*.cmd' -exec rm {} +
 	ln -sf "/usr/src/linux-headers-$version" "headers/lib/modules/$version/build"
 
-	(cd linux; eval $make -j$NPROC INSTALL_KBUILD_PATH="../$destdir" kbuild_install)
+	(cd linux; make "${make_opts[@]}" -j$NPROC INSTALL_KBUILD_PATH="../$destdir" kbuild_install)
 }
 
 NPROC=$(nproc) || NPROC=8
@@ -41,86 +41,64 @@ BUILDDIR=$INSTDIR/kbuild
 export KBUILD_BUILD_TIMESTAMP=$(date --rfc-2822)
 export KBUILD_BUILD_USER="admin"
 export KBUILD_BUILD_HOST="kunbus.de"
-make="make CFLAGS_KERNEL='-fdebug-prefix-map=$LINUXDIR=.' CFLAGS_MODULE='-fdebug-prefix-map=$LINUXDIR=.' ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- O=$BUILDDIR"
+make_opts=(CFLAGS_KERNEL='-fdebug-prefix-map=$LINUXDIR=.' CFLAGS_MODULE='-fdebug-prefix-map=$LINUXDIR=.' ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- O="$BUILDDIR")
 
-rm -rf "$BUILDDIR"
-mkdir "$BUILDDIR"
 if [ ! -L "$INSTDIR/linux" ] ; then
     ln -sf "$LINUXDIR" "$INSTDIR/linux"
 fi
 rm -rf "$INSTDIR/headers"
 
-# build CM1 kernel
-(cd linux; eval $make revpi-v6_defconfig)
-(cd linux; eval $make -j$NPROC zImage modules dtbs 2>&1)
-version=$(cat "$BUILDDIR/include/config/kernel.release")
-[ ! -d "extra" ] && mkdir "extra"
-echo "_ _ $version" > extra/uname_string
-copy_files
-
-# build CM1 piKernelMod
-if [ -d "$PIKERNELMODDIR" ] ; then
-	cd "$PIKERNELMODDIR"
-	make compiletime.h
-	cd -
-	(cd linux; eval $make M="$PIKERNELMODDIR" modules)
-fi
-# install CM1 kernel
-cp "$BUILDDIR/arch/arm/boot/zImage" "$INSTDIR/boot/kernel.img"
-
-# install CM1 modules
-rm -rf modules/*
-if [ -d "$PIKERNELMODDIR" ] ; then
-	(cd linux; eval $make -j$NPROC modules_install INSTALL_MOD_PATH="$INSTDIR/modules" M="$PIKERNELMODDIR")
-fi
-(cd linux; eval $make -j$NPROC modules_install INSTALL_MOD_PATH="$INSTDIR/modules")
-mv "$INSTDIR/modules/lib/modules"/* "$INSTDIR/modules"
-rm -r "$INSTDIR/modules/lib"
-rm "$INSTDIR/modules"/*/{build,source}
-
-# install CM1 dtbs
 [ -d "$INSTDIR/boot/overlays" ] || mkdir "$INSTDIR/boot/overlays"
 rm -f "$INSTDIR/boot"/*.dtb "$INSTDIR/boot/overlays"/*.dtbo
-(cd linux; eval $make -j$NPROC dtbs_install INSTALL_DTBS_PATH=/tmp/dtb.$$)
+
+rm -rf modules/*
+
+# CM1=6 CM3=7 CM4=7l
+kernel_versions="6 7 7l"
+
+for kernel_version in $kernel_versions; do
+    builddir=${BUILDDIR}${kernel_version/6/}
+    make_opts[-1]="O=${builddir}"
+
+    rm -rf "$builddir"
+    mkdir "$builddir"
+
+    # build kernel
+    (cd linux; make "${make_opts[@]}" "revpi-v${kernel_version}_defconfig")
+    (cd linux; make "${make_opts[@]}" -j$NPROC zImage modules 2>&1)
+    version="$(cat "$builddir/include/config/kernel.release")"
+    copy_files
+
+    # build piKernelMod
+    if [ -d "$PIKERNELMODDIR" ] ; then
+      cd "$PIKERNELMODDIR"
+      make compiletime.h
+      cd -
+      (cd linux; make "${make_opts[@]}" M="$PIKERNELMODDIR" modules)
+    fi
+
+    # install kernel
+    cp "$builddir/arch/arm/boot/zImage" "$INSTDIR/boot/kernel${kernel_version/6/}.img"
+
+    # install modules
+    if [ -d "$PIKERNELMODDIR" ] ; then
+      (cd linux; make "${make_opts[@]}" -j$NPROC modules_install INSTALL_MOD_PATH="$INSTDIR/modules" M="$PIKERNELMODDIR")
+    fi
+    (cd linux; make "${make_opts[@]}" -j$NPROC modules_install INSTALL_MOD_PATH="$INSTDIR/modules")
+    mv "$INSTDIR/modules/lib/modules"/* "$INSTDIR/modules"
+    rm -r "$INSTDIR/modules/lib"
+    rm "$INSTDIR/modules"/*/{build,source}
+done
+
+# install dtbs (based on last builddir)
+(cd linux; make "${make_opts[@]}" -j$NPROC dtbs 2>&1)
+(cd linux; make "${make_opts[@]}" -j$NPROC dtbs_install INSTALL_DTBS_PATH=/tmp/dtb.$$)
 mv /tmp/dtb.$$/*.dtb "$INSTDIR/boot"
 mv /tmp/dtb.$$/overlays/* "$INSTDIR/boot/overlays"
 rmdir /tmp/dtb.$$/overlays /tmp/dtb.$$
 
-# build CM3 kernel
-make+=7
-BUILDDIR+=7
-rm -rf "$BUILDDIR"
-mkdir "$BUILDDIR"
-(cd linux; eval $make revpi-v7_defconfig)
-(cd linux; eval $make -j$NPROC zImage modules dtbs 2>&1)
-version="$(cat "$BUILDDIR/include/config/kernel.release")"
-copy_files
-
-# build CM3 piKernelMod
-if [ -d "$PIKERNELMODDIR" ] ; then
-	cd "$PIKERNELMODDIR"
-	make compiletime.h
-	cd -
-	(cd linux; eval $make M="$PIKERNELMODDIR" modules)
-fi
-
-# install CM3 kernel
-cp "$BUILDDIR/arch/arm/boot/zImage" "$INSTDIR/boot/kernel7.img"
-
-# install CM3 modules
-if [ -d "$PIKERNELMODDIR" ] ; then
-	(cd linux; eval $make -j$NPROC modules_install INSTALL_MOD_PATH="$INSTDIR/modules" M="$PIKERNELMODDIR")
-fi
-(cd linux; eval $make -j$NPROC modules_install INSTALL_MOD_PATH="$INSTDIR/modules")
-mv "$INSTDIR/modules/lib/modules"/* "$INSTDIR/modules"
-rm -r "$INSTDIR/modules/lib"
-rm "$INSTDIR/modules"/*/{build,source}
-
-# install CM3 dtbs
-(cd linux; eval $make -j$NPROC dtbs_install INSTALL_DTBS_PATH=/tmp/dtb.$$)
-mv /tmp/dtb.$$/*.dtb "$INSTDIR/boot"
-mv /tmp/dtb.$$/overlays/* "$INSTDIR/boot/overlays"
-rmdir /tmp/dtb.$$/overlays /tmp/dtb.$$
+[ ! -d "extra" ] && mkdir "extra"
+echo "_ _ $version" > extra/uname_string
 
 find headers -name .gitignore -delete
 (cd debian; ./gen_bootloader_postinst_preinst.sh)


### PR DESCRIPTION
This PR removes repeating code fragments for the different compute modules and makes the build process more generic in order to support CM4 with v7l