### PR TITLE
Remove elevator=deadline from the cmdline in postinst

### DIFF
--- a/debian/gen_bootloader_postinst_preinst.sh
+++ b/debian/gen_bootloader_postinst_preinst.sh
@@ -79,6 +79,13 @@ if ! /bin/grep -Eq "^blacklist 8192cu" /etc/modprobe.d/blacklist-rtl8192cu.conf 
   echo "blacklist 8192cu" >> /etc/modprobe.d/blacklist-rtl8192cu.conf
 fi
 /bin/sed -i -e '/^blacklist rtl8192cu/s/^/#/' /etc/modprobe.d/blacklist-rtl8192cu.conf
+
+# Remove deprecated "elevator=deadline" from the cmdline.txt
+# We will only do anything if we are certain that the user has not modfified the
+# relevant part of the cmdline.
+if ! /bin/grep -Fq "rootfstype=ext4 elevator=deadline fsck.repair=yes" /boot/cmdline.txt ; then
+  sed -n -e 's/rootfstype=ext4 elevator=deadline fsck.repair=yes/rootfstype=ext4 fsck.repair=yes/' /boot/cmdline.txt
+fi
 EOF
 
 printf "#DEBHELPER#\n" >> raspberrypi-kernel.postinst


### PR DESCRIPTION
Remove the deadline ioscheduler from the cmdline

Since some time now the kernel (at least 4.19) uses the deadline
scheduler by default. With kernel 5.10 the elevator= option is ignored
and a warning is printed in the kernel log:

  Kernel parameter elevator= does not have any effect anymore.
  Please use sysfs to set IO scheduler for individual devices.

We will remove elevator=deadline from /boot/cmdline.txt on the system. The
user is in control of the this file. And we need to make sure this will not
break anything. So we only remove the string if the options before and
after elevator=deadline also match. If the user has changed the cmdline
he needs to remove the elevator= himself.

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>

This is a draft! I haven't tested this in a package.