### PR TITLE
fix: The removal of elevator= from the cmdline.txt is not working

### DIFF
--- a/debian/gen_bootloader_postinst_preinst.sh
+++ b/debian/gen_bootloader_postinst_preinst.sh
@@ -83,8 +83,8 @@ fi
 # Remove deprecated "elevator=deadline" from the cmdline.txt
 # We will only do anything if we are certain that the user has not modfified the
 # relevant part of the cmdline.
-if ! /bin/grep -Fq "rootfstype=ext4 elevator=deadline fsck.repair=yes" /boot/cmdline.txt ; then
-  sed -n -e 's/rootfstype=ext4 elevator=deadline fsck.repair=yes/rootfstype=ext4 fsck.repair=yes/' /boot/cmdline.txt
+if /bin/grep -Fq "rootfstype=ext4 elevator=deadline fsck.repair=yes" /boot/cmdline.txt ; then
+  sed -i -e 's/rootfstype=ext4 elevator=deadline fsck.repair=yes/rootfstype=ext4 fsck.repair=yes/' /boot/cmdline.txt
 fi
 EOF
 


### PR DESCRIPTION
Wiith commit 1befc18 ("Remove elevator=deadline from the cmdline
in postinst") the option elevator=deadline should be patched out of
/boot/cmdline.txt. But the condition for it was wrong and the sed
command was not change the file.

Invert the check if the string is presen in the cmdline. Also tell sed
to do the changes in-place.

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>