### PR TITLE
Fix a warning about divert behavior change [REVPI-1582] [REVPI-1926]

### DIFF
--- a/debian/gen_bootloader_postinst_preinst.sh
+++ b/debian/gen_bootloader_postinst_preinst.sh
@@ -20,7 +20,7 @@ for FN in ../boot/*.dtb ../boot/kernel*.img ../boot/COPYING.linux ../boot/overla
     printf "dpkg-divert --package rpikernelhack --remove --rename /boot/$FN\n" >> raspberrypi-kernel.postinst
     printf "sync\n" >> raspberrypi-kernel.postinst
 
-    printf "dpkg-divert --package rpikernelhack --divert /usr/share/rpikernelhack/$FN /boot/$FN\n" >> raspberrypi-kernel.preinst
+    printf "dpkg-divert --package rpikernelhack --rename --divert /usr/share/rpikernelhack/$FN /boot/$FN\n" >> raspberrypi-kernel.preinst
   fi
 done
 


### PR DESCRIPTION
When installing the kernel the following warning is printed for ever
file installied to /boot.

dpkg-divert: warning: please specify --no-rename explicitly,
the default will change to --rename in 1.20.x

Add --rename to the dpkg-divert call to silence the warning.

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>