### PR TITLE
Add git and rsync to the list of packages

### DIFF
--- a/README
+++ b/README
@@ -16,7 +16,7 @@ Intended usage:
     apt-get install device-tree-compiler
     apt-get install gcc-arm-linux-gnueabihf
     apt-get install build-essential:native debhelper quilt bc
-    apt-get install bison flex libssl-dev
+    apt-get install bison flex libssl-dev rsync git
     git clone -b revpi-5.10 https://github.com/RevolutionPi/linux
     git clone -b master https://github.com/RevolutionPi/piControl
     git clone -b master https://github.com/RevolutionPi/kernelbakery


### PR DESCRIPTION
Without git the repos can't be cloned. And rsync is used in the
update.sh script.

Add git and rsync to the package which should be installed.

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>