### PR TITLE
update.sh: check if source folders exists [REVPI-2284]

### DIFF
--- a/debian/update.sh
+++ b/debian/update.sh
@@ -33,6 +33,16 @@ NPROC=$(nproc) || NPROC=8
 if [ -z "$LINUXDIR" ] ; then
     echo 1>&2 "Usage: LINUXDIR=<path> [PIKERNELMODDIR=<path>] $(basename "$0")"
     exit 1
+elif [ ! -d "$LINUXDIR" ] ; then
+    echo 1>&2 "LINUXDIR defined as $LINUXDIR, but folder not found on disk."
+    exit 1
+fi
+
+if [ -n "$PIKERNELMODDIR" ] ; then
+    if [ ! -d "$PIKERNELMODDIR" ] ; then
+        echo 1>&2 "PIKERNELMODDIR defined as $PIKERNELMODDIR, but folder not found on disk."
+        exit 1
+    fi
 fi
 
 INSTDIR=$(dirname "$0")


### PR DESCRIPTION
When building a new kernel package, environment variables must be set
for the linux kernel sources and additional for the picontrol sources.
If the variables are set, there was no check if the folder really
exists. The kernel build would abort in some way. As the build of
picontrol is optional, the build will not check for the source folder of
pictrontrol if it should be built into the package.

Add a check so that the script validates the existence of the folders
if the corresponding environment variable LINUXDIR or PIKERNELMODDIR is
set.

Signed-off-by: Frank Erdrich <f.erdrich@kunbus.com>