### PR TITLE
Optional arm64 builds [REVPI-2714]

### DIFF
--- a/README
+++ b/README
@@ -12,7 +12,7 @@ all their kernels and modules in binary form dating back to 2012.  That's why
 this repo was stripped of the git history as well as files which can be rebuilt
 from the kernel source tree.
 
-Intended usage:
+Intended usage (32-bit kernel):
     apt-get install device-tree-compiler
     apt-get install gcc-arm-linux-gnueabihf
     apt-get install build-essential:native debhelper quilt bc
@@ -23,6 +23,18 @@ Intended usage:
     cd kernelbakery
     LINUXDIR=$PWD/../linux PIKERNELMODDIR=$PWD/../piControl debian/update.sh
     dpkg-buildpackage -a armhf -b -us -uc
+
+Intended usage (64-bit kernel):
+    apt-get install device-tree-compiler
+    apt-get install gcc-aarch64-linux-gnu
+    apt-get install build-essential:native debhelper quilt bc
+    apt-get install bison flex libssl-dev rsync git
+    git clone -b revpi-5.10 https://github.com/RevolutionPi/linux
+    git clone -b master https://github.com/RevolutionPi/piControl
+    git clone -b master https://github.com/RevolutionPi/kernelbakery
+    cd kernelbakery
+    ARCH=arm64 LINUXDIR=$PWD/../linux PIKERNELMODDIR=$PWD/../piControl debian/update.sh
+    dpkg-buildpackage -a arm64 -b -us -uc
 
 This procedure was tested successfully on Debian buster amd64, but YMMV.
 Building the kernel with update.sh is idempotent.  If it fails, e.g. due to

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Vcs-Browser: https://github.com/RevolutionPi/kernelbakery
 
 Package: raspberrypi-kernel
 Section: kernel
-Architecture: armel armhf
+Architecture: armel armhf arm64
 Multi-Arch: foreign
 Depends: ${misc:Depends}, raspberrypi-bootloader (>= 1.20160506-1)
 Breaks: raspberrypi-bootloader (<<1.20160324-1)

--- a/debian/gen_bootloader_postinst_preinst.sh
+++ b/debian/gen_bootloader_postinst_preinst.sh
@@ -30,6 +30,7 @@ if [ -d "/etc/kernel/preinst.d" ]; then
   run-parts -v --report --exit-on-error --arg=${version}+ --arg=/boot/kernel.img /etc/kernel/preinst.d
   run-parts -v --report --exit-on-error --arg=${version}-v7+ --arg=/boot/kernel7.img /etc/kernel/preinst.d
   run-parts -v --report --exit-on-error --arg=${version}-v7l+ --arg=/boot/kernel7l.img /etc/kernel/preinst.d
+  run-parts -v --report --exit-on-error --arg=${version}-v8+ --arg=/boot/kernel8.img /etc/kernel/preinst.d
 fi
 if [ -d "/etc/kernel/preinst.d/${version}+" ]; then
   run-parts -v --report --exit-on-error --arg=${version}+ --arg=/boot/kernel.img /etc/kernel/preinst.d/${version}+
@@ -40,6 +41,9 @@ fi
 if [ -d "/etc/kernel/preinst.d/${version}-v7l+" ]; then
   run-parts -v --report --exit-on-error --arg=${version}-v7l+ --arg=/boot/kernel7l.img /etc/kernel/preinst.d/${version}-v7l+
 fi
+if [ -d "/etc/kernel/preinst.d/${version}-v8+" ]; then
+  run-parts -v --report --exit-on-error --arg=${version}-v8+ --arg=/boot/kernel8.img /etc/kernel/preinst.d/${version}-v8+
+fi
 EOF
 
 cat <<EOF >> raspberrypi-kernel.postinst
@@ -48,6 +52,7 @@ if [ -d "/etc/kernel/postinst.d" ]; then
   run-parts -v --report --exit-on-error --arg=${version}+ --arg=/boot/kernel.img /etc/kernel/postinst.d
   run-parts -v --report --exit-on-error --arg=${version}-v7+ --arg=/boot/kernel7.img /etc/kernel/postinst.d
   run-parts -v --report --exit-on-error --arg=${version}-v7l+ --arg=/boot/kernel7l.img /etc/kernel/postinst.d
+  run-parts -v --report --exit-on-error --arg=${version}-v8+ --arg=/boot/kernel8.img /etc/kernel/postinst.d
 fi
 if [ -d "/etc/kernel/postinst.d/${version}+" ]; then
   run-parts -v --report --exit-on-error --arg=${version}+ --arg=/boot/kernel.img /etc/kernel/postinst.d/${version}+
@@ -57,6 +62,9 @@ if [ -d "/etc/kernel/postinst.d/${version}-v7+" ]; then
 fi
 if [ -d "/etc/kernel/postinst.d/${version}-v7l+" ]; then
   run-parts -v --report --exit-on-error --arg=${version}-v7l+ --arg=/boot/kernel7l.img /etc/kernel/postinst.d/${version}-v7l+
+fi
+if [ -d "/etc/kernel/postinst.d/${version}-v8+" ]; then
+  run-parts -v --report --exit-on-error --arg=${version}-v8+ --arg=/boot/kernel8.img /etc/kernel/postinst.d/${version}-v8+
 fi
 
 # wheezy and jessie images shipped with a "kunbus" overlay
@@ -101,6 +109,7 @@ if [ -d "/etc/kernel/prerm.d" ]; then
   run-parts -v --report --exit-on-error --arg=${version}+ --arg=/boot/kernel.img /etc/kernel/prerm.d
   run-parts -v --report --exit-on-error --arg=${version}-v7+ --arg=/boot/kernel7.img /etc/kernel/prerm.d
   run-parts -v --report --exit-on-error --arg=${version}-v7l+ --arg=/boot/kernel7l.img /etc/kernel/prerm.d
+  run-parts -v --report --exit-on-error --arg=${version}-v8+ --arg=/boot/kernel8.img /etc/kernel/prerm.d
 fi
 if [ -d "/etc/kernel/prerm.d/${version}+" ]; then
   run-parts -v --report --exit-on-error --arg=${version}+ --arg=/boot/kernel.img /etc/kernel/prerm.d/${version}+
@@ -111,6 +120,9 @@ fi
 if [ -d "/etc/kernel/prerm.d/${version}-v7l+" ]; then
   run-parts -v --report --exit-on-error --arg=${version}-v7l+ --arg=/boot/kernel7l.img /etc/kernel/prerm.d/${version}-v7l+
 fi
+if [ -d "/etc/kernel/prerm.d/${version}-v8+" ]; then
+  run-parts -v --report --exit-on-error --arg=${version}-v8+ --arg=/boot/kernel8.img /etc/kernel/prerm.d/${version}-v8+
+fi
 EOF
 
 cat <<EOF >> raspberrypi-kernel.postrm
@@ -119,6 +131,7 @@ if [ -d "/etc/kernel/postrm.d" ]; then
   run-parts -v --report --exit-on-error --arg=${version}+ --arg=/boot/kernel.img /etc/kernel/postrm.d
   run-parts -v --report --exit-on-error --arg=${version}-v7+ --arg=/boot/kernel7.img /etc/kernel/postrm.d
   run-parts -v --report --exit-on-error --arg=${version}-v7l+ --arg=/boot/kernel7l.img /etc/kernel/postrm.d
+  run-parts -v --report --exit-on-error --arg=${version}-v8+ --arg=/boot/kernel8.img /etc/kernel/postrm.d
 fi
 if [ -d "/etc/kernel/postrm.d/${version}+" ]; then
   run-parts -v --report --exit-on-error --arg=${version}+ --arg=/boot/kernel.img /etc/kernel/postrm.d/${version}+
@@ -129,6 +142,9 @@ fi
 if [ -d "/etc/kernel/postrm.d/${version}-v7l+" ]; then
   run-parts -v --report --exit-on-error --arg=${version}-v7l+ --arg=/boot/kernel7l.img /etc/kernel/postrm.d/${version}-v7l+
 fi
+if [ -d "/etc/kernel/postrm.d/${version}-v8+" ]; then
+  run-parts -v --report --exit-on-error --arg=${version}-v8+ --arg=/boot/kernel8.img /etc/kernel/postrm.d/${version}-v8+
+fi
 EOF
 
 cat <<EOF >> raspberrypi-kernel-headers.postinst
@@ -137,6 +153,7 @@ if [ -d "/etc/kernel/header_postinst.d" ]; then
   run-parts -v --verbose --exit-on-error --arg=${version}+ /etc/kernel/header_postinst.d
   run-parts -v --verbose --exit-on-error --arg=${version}-v7+ /etc/kernel/header_postinst.d
   run-parts -v --verbose --exit-on-error --arg=${version}-v7l+ /etc/kernel/header_postinst.d
+  run-parts -v --verbose --exit-on-error --arg=${version}-v8+ /etc/kernel/header_postinst.d
 fi
 
 if [ -d "/etc/kernel/header_postinst.d/${version}+" ]; then
@@ -149,6 +166,10 @@ fi
 
 if [ -d "/etc/kernel/header_postinst.d/${version}-v7l+" ]; then
   run-parts -v --verbose --exit-on-error --arg=${version}-v7l+ /etc/kernel/header_postinst.d/${version}-v7l+
+fi
+
+if [ -d "/etc/kernel/header_postinst.d/${version}-v8+" ]; then
+  run-parts -v --verbose --exit-on-error --arg=${version}-v8+ /etc/kernel/header_postinst.d/${version}-v8+
 fi
 EOF
 

--- a/debian/update.sh
+++ b/debian/update.sh
@@ -8,19 +8,19 @@ copy_files (){
 	rsync -aHAX \
 		--files-from=<(cd linux; find . -name Makefile\* -o -name Kconfig\* -o -name \*.pl | grep -E -v '^\./debian') linux/ "$destdir/"
 	rsync -aHAX \
-		--files-from=<(cd linux; find arch/arm/include include scripts -type f) linux/ "$destdir/"
+		--files-from=<(cd linux; find arch/${ARCH}/include include scripts -type f) linux/ "$destdir/"
 	rsync -aHAX \
-		--files-from=<(cd linux; find arch/arm -name module.lds -o -name Kbuild.platforms -o -name Platform) linux/ "$destdir/"
+		--files-from=<(cd linux; find arch/${ARCH} -name module.lds -o -name Kbuild.platforms -o -name Platform) linux/ "$destdir/"
 	rsync -aHAX \
 		--files-from=<( \
 				cd linux; \
-				find arch/arm -name include -type d -print0 -o -name scripts -type d -print0 | \
+				find arch/${ARCH} -name include -type d -print0 -o -name scripts -type d -print0 | \
 				xargs -0 -I '{}' find '{}' -type f \
 			) \
 			linux/ \
 			"$destdir/"
 	rsync -aHAX \
-		--files-from=<(cd "$builddir"; find arch/arm/include Module.symvers .config include scripts -type f) "$builddir" "$destdir/"
+		--files-from=<(cd "$builddir"; find arch/${ARCH}/include Module.symvers .config include scripts -type f) "$builddir" "$destdir/"
 	find "$destdir/scripts" -type f -exec file {} + | grep -E 'ELF .* x86-64' | cut -d: -f1 | xargs rm
 	find "$destdir/scripts" -type f -name '*.cmd' -exec rm {} +
 	ln -sf "/usr/src/linux-headers-$version" "headers/lib/modules/$version/build"
@@ -45,6 +45,24 @@ if [ -n "$PIKERNELMODDIR" ] ; then
     fi
 fi
 
+ARCH=${ARCH:-arm}
+case "$ARCH" in
+	arm)
+		CROSS_COMPILE=${CROSS_COMPILE:-arm-linux-gnueabihf-}
+		# CM1=6 CM3=7 CM4=7l (32 bit kernel)
+		kernel_versions="6 7 7l"
+		;;
+	arm64)
+		CROSS_COMPILE=${CROSS_COMPILE:-aarch64-linux-gnu-}
+		# CM3/CM4S/CM4=8 (64 bit kernel)
+		kernel_versions="8"
+		;;
+	*)
+		echo 1>&2 "Unsupported architecture: ${ARCH}"
+		exit 1
+		;;
+esac
+
 INSTDIR=$(dirname "$0")
 if [ "${INSTDIR#/}" == "$INSTDIR" ] ; then INSTDIR="$PWD/$INSTDIR" ; fi
 INSTDIR=${INSTDIR%%/debian}
@@ -52,24 +70,24 @@ BUILDDIR_TEMPLATE=$INSTDIR/kbuild
 export KBUILD_BUILD_TIMESTAMP=$(date --rfc-2822)
 export KBUILD_BUILD_USER="support"
 export KBUILD_BUILD_HOST="kunbus.com"
-make_opts=(CFLAGS_KERNEL='-fdebug-prefix-map=$LINUXDIR=.' CFLAGS_MODULE='-fdebug-prefix-map=$LINUXDIR=.' ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- O="$BUILDDIR_TEMPLATE")
+export ARCH
+export CROSS_COMPILE
+make_opts=(CFLAGS_KERNEL='-fdebug-prefix-map=$LINUXDIR=.' CFLAGS_MODULE='-fdebug-prefix-map=$LINUXDIR=.' O="$BUILDDIR_TEMPLATE")
 
 if [ ! -L "$INSTDIR/linux" ] ; then
     ln -sf "$LINUXDIR" "$INSTDIR/linux"
 fi
-rm -rf "$INSTDIR/headers"
 
 [ -d "$INSTDIR/boot/overlays" ] || mkdir "$INSTDIR/boot/overlays"
-rm -f "$INSTDIR/boot"/*.dtb "$INSTDIR/boot/overlays"/*.dtbo
 
+# cleanup from previous builds
+rm -rf "$INSTDIR/headers"
+rm -f "$INSTDIR/boot/broadcom"/*.dtb "$INSTDIR/boot"/*.dtb "$INSTDIR/boot/overlays"/*.dtbo "$INSTDIR/boot"/kernel*.img
 rm -rf modules/*
-
-# CM1=6 CM3=7 CM4=7l
-kernel_versions="6 7 7l"
 
 for kernel_version in $kernel_versions; do
     defconfig="revpi-v${kernel_version}_defconfig"
-    test -f "linux/arch/arm/configs/$defconfig" || continue
+    test -f "linux/arch/${ARCH}/configs/$defconfig" || continue
     builddir=${BUILDDIR_TEMPLATE}${kernel_version/6/}
     make_opts[-1]="O=${builddir}"
 
@@ -78,7 +96,11 @@ for kernel_version in $kernel_versions; do
 
     # build kernel
     (cd linux; make "${make_opts[@]}" $defconfig)
-    (cd linux; make "${make_opts[@]}" -j$NPROC zImage modules 2>&1)
+    if [ "$ARCH" == "arm64" ]; then
+	    (cd linux; make "${make_opts[@]}" -j$NPROC Image modules 2>&1)
+    else
+	    (cd linux; make "${make_opts[@]}" -j$NPROC zImage modules 2>&1)
+    fi
     version="$(cat "$builddir/include/config/kernel.release")"
     copy_files "$builddir"
 
@@ -91,7 +113,15 @@ for kernel_version in $kernel_versions; do
     fi
 
     # install kernel
-    cp "$builddir/arch/arm/boot/zImage" "$INSTDIR/boot/kernel${kernel_version/6/}.img"
+
+    if [ "$ARCH" == "arm64" ]; then
+	    # arm64 kernel is uncompressed by default, let's gzip it
+	    cp "$builddir/arch/${ARCH}/boot/Image" "$INSTDIR/boot/kernel8.img"
+	    gzip "$INSTDIR/boot/kernel8.img"
+	    mv "$INSTDIR/boot/kernel8.img"{.gz,}
+    else
+	    cp "$builddir/arch/${ARCH}/boot/zImage" "$INSTDIR/boot/kernel${kernel_version/6/}.img"
+    fi
 
     # install modules
     if [ -d "$PIKERNELMODDIR" ] ; then
@@ -106,9 +136,13 @@ done
 # install dtbs (based on last builddir)
 (cd linux; make "${make_opts[@]}" -j$NPROC dtbs 2>&1)
 (cd linux; make "${make_opts[@]}" -j$NPROC dtbs_install INSTALL_DTBS_PATH=/tmp/dtb.$$)
-mv /tmp/dtb.$$/*.dtb "$INSTDIR/boot"
+if [ "$ARCH" == "arm64" ]; then
+	mv /tmp/dtb.$$/broadcom/*.dtb "$INSTDIR/boot"
+else
+	mv /tmp/dtb.$$/*.dtb "$INSTDIR/boot"
+fi
 mv /tmp/dtb.$$/overlays/* "$INSTDIR/boot/overlays"
-rmdir /tmp/dtb.$$/overlays /tmp/dtb.$$
+rmdir /tmp/dtb.$$/* /tmp/dtb.$$
 
 [ ! -d "extra" ] && mkdir "extra"
 echo "_ _ $version" > extra/uname_string

--- a/debian/update.sh
+++ b/debian/update.sh
@@ -117,7 +117,7 @@ for kernel_version in $kernel_versions; do
     if [ "$ARCH" == "arm64" ]; then
 	    # arm64 kernel is uncompressed by default, let's gzip it
 	    cp "$builddir/arch/${ARCH}/boot/Image" "$INSTDIR/boot/kernel8.img"
-	    gzip "$INSTDIR/boot/kernel8.img"
+	    gzip -9 "$INSTDIR/boot/kernel8.img"
 	    mv "$INSTDIR/boot/kernel8.img"{.gz,}
     else
 	    cp "$builddir/arch/${ARCH}/boot/zImage" "$INSTDIR/boot/kernel${kernel_version/6/}.img"


### PR DESCRIPTION
With arm64 support in our kernel and piControl repository, we need to adapt our build scripts as well. This PR introduces optional arm64 support for the kernelbakery. The architecture of choice (eg. `arm` or `arm64`) can be specified with the env var `ARCH`. If the user does not provide `ARCH`, the build script assumes the former default value `arm`

Details about the differences between `arm` and `arm64` builds can be found in the description of the linked ticket.