### PR TITLE
Reproducible build: KBUILD_BUILD_TIMESTAMP

### DIFF
--- a/debian/update.sh
+++ b/debian/update.sh
@@ -67,7 +67,8 @@ INSTDIR=$(dirname "$0")
 if [ "${INSTDIR#/}" == "$INSTDIR" ] ; then INSTDIR="$PWD/$INSTDIR" ; fi
 INSTDIR=${INSTDIR%%/debian}
 BUILDDIR_TEMPLATE=$INSTDIR/kbuild
-export KBUILD_BUILD_TIMESTAMP=$(date --rfc-2822)
+KBUILD_BUILD_TIMESTAMP="$(dpkg-parsechangelog -STimestamp)"
+export KBUILD_BUILD_TIMESTAMP
 export KBUILD_BUILD_USER="support"
 export KBUILD_BUILD_HOST="kunbus.com"
 export ARCH


### PR DESCRIPTION
Use the changelog date instead the current date to provide reproducible builds.

https://www.debian.org/doc/manuals/debmake-doc/ch05.en.html#reproducible https://reproducible-builds.org/docs/source-date-epoch/

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>