### PR TITLE
Don't run xargs on empty string

### DIFF
--- a/debian/update.sh
+++ b/debian/update.sh
@@ -33,8 +33,12 @@ copy_files() {
             cd "$builddir"
             find "arch/${ARCH}/include" Module.symvers .config include scripts -type f
         ) "$builddir" "$destdir/"
-    find "$destdir/scripts" -type f -exec file {} + | grep -E 'ELF .* x86-64' | cut -d: -f1 | xargs rm
+
+    # search for artifacts which have been built for host architecture and remove them
+    HOST_ELF=$(file /bin/true | grep -oP 'ELF [\w- ]+, \K[\w- ]+')
+    find "$destdir/scripts" -type f -exec file {} + | grep -E "ELF .* $HOST_ELF," | cut -d: -f1 | xargs --no-run-if-empty rm
     find "$destdir/scripts" -type f -name '*.cmd' -exec rm {} +
+
     ln -sf "/usr/src/linux-headers-$version" "headers/lib/modules/$version/build"
 
     (


### PR DESCRIPTION
The current approach with fails on systems which are not x86_64 with the following error message:

  LD [M]  sound/usb/line6/snd-usb-line6.ko
  LD [M]  sound/usb/line6/snd-usb-toneport.ko
  LD [M]  sound/usb/misc/snd-ua101.ko
  LD [M]  sound/usb/snd-usb-audio.ko
  LD [M]  sound/usb/snd-usbmidi-lib.ko
make[1]: Leaving directory '/home/pi/kernelbakery/kbuild' rm: missing operand
Try 'rm --help' for more information.

This is caused by the implementation in line 36 of debian/update.sh and the false assumption that there will be always files matching 'ELF .* x86-64'. On other systems where nothing is found 'xargs rm' is called with an empty stdin which fails with the error message above.

Fix this by running xargs only on non-empty input.

This behaviour was initially reported by Simon on 2022-11-22.

Signed-off-by: Nicolai Buchwitz <n.buchwitz@kunbus.com>