### PR TITLE
Check for blacklist file before working with it

### DIFF
--- a/debian/gen_bootloader_postinst_preinst.sh
+++ b/debian/gen_bootloader_postinst_preinst.sh
@@ -83,10 +83,12 @@ fi
   done
 
 # 8192cu is unreliable on 4.9, blacklist it and unblacklist rtl8192cu
-if ! /bin/grep -Eq "^blacklist 8192cu" /etc/modprobe.d/blacklist-rtl8192cu.conf ; then
-  echo "blacklist 8192cu" >> /etc/modprobe.d/blacklist-rtl8192cu.conf
+if [ -f /etc/modprobe.d/blacklist-rtl8192cu.conf ]; then
+  if ! /bin/grep -Eq "^blacklist 8192cu" /etc/modprobe.d/blacklist-rtl8192cu.conf ; then
+    echo "blacklist 8192cu" >> /etc/modprobe.d/blacklist-rtl8192cu.conf
+  fi
+  /bin/sed -i -e '/^blacklist rtl8192cu/s/^/#/' /etc/modprobe.d/blacklist-rtl8192cu.conf
 fi
-/bin/sed -i -e '/^blacklist rtl8192cu/s/^/#/' /etc/modprobe.d/blacklist-rtl8192cu.conf
 
 # Remove deprecated "elevator=deadline" from the cmdline.txt
 # We will only do anything if we are certain that the user has not modfified the


### PR DESCRIPTION
The blacklist file /etc/modprobe.d/blacklist-rtl8192cu.conf is added by our imagebakery and therefore not part of the official Raspberry Pi OS image. If a user tries to install our kernel on the vanilla RPi OS this will fail.

Fix this by checking first if the file is present and skip the steps if absent.