### PR TITLE
Create 1:9.20230425+1-5.10.152-1+revpi10+1 release (Buster) [REVPI-3073]

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-raspberrypi-firmware (1:9.20230425+1-5.10.152-1) UNRELEASED; urgency=medium
+raspberrypi-firmware (1:9.20230425+1-5.10.152-1+revpi10+1) buster; urgency=medium
 
   [Linux kernel changelog]
   * net: phy: broadcom: Make LEDs 3+4 shadow LEDs 1+2
@@ -23,7 +23,7 @@ raspberrypi-firmware (1:9.20230425+1-5.10.152-1) UNRELEASED; urgency=medium
   * Replace strncpy by snprintf
   * Fix gcc -Wformat= complaints
 
- -- Philipp Rosenberger <p.rosenberger@kunbus.com>  Tue, 25 Apr 2023 14:11:24 +0200
+ -- Philipp Rosenberger <p.rosenberger@kunbus.com>  Wed, 26 Apr 2023 16:51:10 +0200
 
 raspberrypi-firmware (1:9.20221118-5.10.152+revpi1) stable; urgency=medium
 


### PR DESCRIPTION
Using a new version format:

$EPOCH:9.$DATE+$COUNT-$KERNEL_VERSION-$DEBIAN_REVSION+revpi$DEBIAN_RELEASE+$PACKAGE_REVISION

EPOCH: The epoch as described in [1]. We need to set the epoch at least
       as high as the epoch in the package from RaspiOS.

DATE: The current date as $(date "+%Ymd") would produce it

COUNT: If more than one package is released on the same date, this
       counter must be increased every time. The counter starts from 1
       every day.

KERNEL_VERSION: As VERSION.PATCHLEVEL.SUBLEVEL from the kernels
                Makefile.

DEBIAN_REVISION: This is usually -1 and represents only the counter of
                 the the debian revision.

DEBIAN_RELEASE: The version of the Debian release 10 for Buster, 11 for
                Bullseye. (lsb_release -r)

PACKAGE_REVSISION: Starts at 1 and is to be increased if a rebuild or
                   non-functional change needs to be done to the package
                   e.g. a package rebuild or some changes in the
                   debianization.

[1] https://www.debian.org/doc/debian-policy/ch-controlfields.html#version