### PR TITLE
fix: Use the Date field of the changelog file instead of the timestamp

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,10 @@
-raspberrypi-firmware (1:9.20230425+1-5.10.152-1) UNRELEASED; urgency=medium
+raspberrypi-firmware (1:9.20230425+1-5.10.152-2) UNRELEASED; urgency=medium
+
+  * Rebuild with correct KBUILD_BUILD_TIMESTAMP
+
+ -- Philipp Rosenberger <p.rosenberger@kunbus.com>  Thu, 27 Apr 2023 15:31:23 +0200
+
+raspberrypi-firmware (1:9.20230425+1-5.10.152-1) stable; urgency=medium
 
   [Linux kernel changelog]
   * net: phy: broadcom: Make LEDs 3+4 shadow LEDs 1+2

--- a/debian/update.sh
+++ b/debian/update.sh
@@ -91,7 +91,7 @@ INSTDIR=$(dirname "$0")
 if [ "${INSTDIR#/}" == "$INSTDIR" ]; then INSTDIR="$PWD/$INSTDIR"; fi
 INSTDIR=${INSTDIR%%/debian}
 BUILDDIR_TEMPLATE=$INSTDIR/kbuild
-KBUILD_BUILD_TIMESTAMP="$(dpkg-parsechangelog -STimestamp)"
+KBUILD_BUILD_TIMESTAMP="$(dpkg-parsechangelog -SDate)"
 export KBUILD_BUILD_TIMESTAMP
 export KBUILD_BUILD_USER="support"
 export KBUILD_BUILD_HOST="kunbus.com"


### PR DESCRIPTION
The option -STimestamp to dpkg-parsechangelog gives a unix timestamp. But the KBUILD_BUILD_TIMESTAMP is usually not a Unix timestamp, but a human readable date and time. The time is given in RFC2888 format.

Use the Date field instead of the timestamp field.

Fixes: 027226c72091 ("Reproducible build: KBUILD_BUILD_TIMESTAMP")