### PR TITLE
build: Don't build armv6 by default [REVPI-3206]

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Building the kernel with update.sh is idempotent. If it fails, e.g. due to
 compiler errors in piControl, just start it afresh. You are also welcome to
 ask your questions in our community forum: https://revolutionpi.de/forum/
 
+Note that since bullseye armv6 is no longer officially supported and is thus
+disabled by default.
+
 ## Install build tools
 
 ```
@@ -72,6 +75,8 @@ cd kernelbakery
 LINUXDIR=$PWD/../linux PIKERNELMODDIR=$PWD/../piControl debian/update.sh
 dpkg-buildpackage -a armhf -b -us -uc
 ```
+
+To build the kernel for armv6, add `-a armv6`.
 
 ### Build 64-bit kernel (v8)
 

--- a/debian/update.sh
+++ b/debian/update.sh
@@ -50,11 +50,17 @@ copy_files() {
 NPROC=$(nproc) || NPROC=8
 
 if [ -z "$LINUXDIR" ]; then
-    echo 1>&2 "Usage: LINUXDIR=<path> [PIKERNELMODDIR=<path>] $(basename "$0")"
+    echo "Usage: LINUXDIR=<path> [PIKERNELMODDIR=<path>] $(basename "$0")" \
+        "[-a armv6]" 1>&2
     exit 1
 elif [ ! -d "$LINUXDIR" ]; then
     echo 1>&2 "LINUXDIR defined as $LINUXDIR, but folder not found on disk."
     exit 1
+fi
+
+if [ "$1" = "-a" ] && [ "$2" = "armv6" ]; then
+    echo "armv6 build enabled" 1>&2
+    ENABLE_ARMV6=1
 fi
 
 if [ -n "$PIKERNELMODDIR" ]; then
@@ -72,7 +78,11 @@ arm)
         CROSS_COMPILE=arm-linux-gnueabihf-
     fi
     # CM1=6 CM3=7 CM4=7l (32 bit kernel)
-    kernel_versions="6 7 7l"
+    # CM1=6 is no longer enabled by default
+    if [ "$ENABLE_ARMV6" ]; then
+        kernel_versions="6 "
+    fi
+    kernel_versions+="7 7l"
     ;;
 arm64)
     if [ "$HOST_ARCH" != "aarch64" ]; then


### PR DESCRIPTION
armv6 builds are not supported by default by the kernelbakery anymore and are now disabled.
The armv6 build can optionally be enabled again with `-a armv6`.

Parsing of `-a armv6` is done by hand. This can be switched to using `getopt` if desired.
Parsing this manually doesn't allow specifying `-aarmv6`, unlike when using `getopt`.