### PR TITLE
Prepare 9.20230720+1-5.10.152-1 release [REVPI-3366]

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,15 @@
-raspberrypi-firmware (1:9.20230627+1-5.10.152-1) UNRELEASED; urgency=medium
+raspberrypi-firmware (1:9.20230720+1-5.10.152-1) UNRELEASED; urgency=medium
+
+  [Linux kernel changelog]
+  * cfg80211: ship debian certificates as hex files
+  * dts: core-se: Disable spi0
+
+  [picontrol changelog]
+  * Add README with basic build instructions
+
+ -- Thomas Böhler <t.boehler@kunbus.com>  Thu, 20 Jul 2023 11:34:42 +0200
+
+raspberrypi-firmware (1:9.20230627+1-5.10.152-1) stable; urgency=medium
 
   [Linux kernel changelog]
   * dts: connect4: Switch left sniff pins


### PR DESCRIPTION
Please review the following tags as well:

* https://github.com/tboehler1/linux/releases/tag/raspberrypi-kernel_1%259.20230720%2B1-5.10.152-1
* https://github.com/tboehler1/piControl/releases/tag/raspberrypi-kernel_1%259.20230720%2B1-5.10.152-1