### PR TITLE
Create 9.20230901+1-5.10.152-1+revpi11+2 release

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+raspberrypi-firmware (1:9.20230901+1-5.10.152-1+revpi11+2) bullseye; urgency=medium
+
+  * Package rebuild for Bullseye arm64 only
+
+ -- Philipp Rosenberger <p.rosenberger@kunbus.com>  Tue, 12 Sep 2023 16:06:10 +0200
+
 raspberrypi-firmware (1:9.20230901+1-5.10.152-1+revpi11+1) bullseye; urgency=medium
 
   [Linux kernel changelog]


### PR DESCRIPTION
This is just a package rebuild for arm64 only. The 9.20230901+1-5.10.152-1+revpi11+1 package for arm64 was missing the piControl module.

https://revolutionpi.com/forum/viewtopic.php?t=4099